### PR TITLE
Allow users to login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 29-05-2021
+### Updated
+- Update OTP request
+
 ## [1.4.1] - 18-04-2021
 ### Updated
 - Login stored procedure

--- a/SensateIot.SmartEnergy.Dsmr.ProductDatabase.sqlproj
+++ b/SensateIot.SmartEnergy.Dsmr.ProductDatabase.sqlproj
@@ -22,7 +22,7 @@
     <SqlServerVerification>False</SqlServerVerification>
     <IncludeCompositeObjects>True</IncludeCompositeObjects>
     <TargetDatabaseSet>True</TargetDatabaseSet>
-    <DacVersion>1.4.1.0</DacVersion>
+    <DacVersion>1.4.2.0</DacVersion>
     <DacApplicationName>DsmrProduct</DacApplicationName>
     <Recovery>SIMPLE</Recovery>
     <PageVerify>CHECKSUM</PageVerify>

--- a/dbo/Stored Procedures/DsmrApi_ResetOtpToken.sql
+++ b/dbo/Stored Procedures/DsmrApi_ResetOtpToken.sql
@@ -12,7 +12,8 @@ BEGIN
 	WHERE [Email] = @email
 
 	UPDATE [dbo].[Users]
-	SET [OnboardingToken] = @token
+	SET [OnboardingToken] = @token,
+	    [Enabled] = 0
 	WHERE [Email] = @email
 
 	IF @@ROWCOUNT >= 1


### PR DESCRIPTION
Allow users to log in after sending an OTP request. In the current situation, users can only log in the first time, or after
having logged out. This patch resets the login status after sending an OTP.